### PR TITLE
Assert markers.empty() in tapeimage.read_header

### DIFF
--- a/src/tapeimage.cpp
+++ b/src/tapeimage.cpp
@@ -185,7 +185,8 @@ int tapeimage::eof() const noexcept (true) {
 }
 
 void tapeimage::read_header() noexcept (false) {
-    assert(this->current     == this->markers.end() or
+    assert(this->markers.empty()                    or
+           this->current     == this->markers.end() or
            this->current + 1 == this->markers.end());
 
     std::int64_t n;


### PR DESCRIPTION
The tapeimage.read_header asserts that actually reading the header from
disk makes sense, which is when there are no more records past the
current in the index. The assert is checking this->current, but
this->current is not yet set when reading the *first* header (during
construction), so the comparison with the index' end() is invalid.

Reading the header is a valid operation when the index is empty, so
simply assert this first. Short-circuiting ensures that if the index is
empty, the iterators are never compared.