### PR TITLE
Circle CI ubsan fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,8 @@ jobs:
   ubsan:
     docker:
       - image: ubuntu:rolling
+    environment:
+      DEBIAN_FRONTEND: noninteractive
     steps:
       - checkout
       - install_build_deps:


### PR DESCRIPTION
ubsan fix only.
It looks like CircleCI doesn't support s390x architecture and setting CI for Windows and Mac requires more time.