### PR TITLE
Re-design the internal details of the rp66 protocol

### DIFF
--- a/include/lfp/rp66.h
+++ b/include/lfp/rp66.h
@@ -40,9 +40,6 @@ extern "C" {
  * position. However, it's not possible to open the protocol in the middle
  * of a record.
  *
- * Should the function fail, a nullptr is returned and it will not obtain
- * ownership over the passed protocol.
- *
  * [1] http://w3.energistics.org/RP66/V1/Toc/main.html
  */
 lfp_protocol* lfp_rp66_open(lfp_protocol*);

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -452,6 +452,7 @@ std::int64_t rp66::readinto(void* dst, std::int64_t len) noexcept (false) {
         if (this->current.exhausted()) {
             if (this->current == this->index.last()) {
                 this->read_header_from_disk();
+                if (this->eof()) return bytes_read;
                 this->current.move(this->index.last());
             } else {
                 const auto next = this->current.next_record();

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -69,7 +69,7 @@ private:
  * The record headers already read by rp66, stored in an order
  * (lower-address first fashion).
  */
-class record_index : public std::vector< header > {
+class record_index : private std::vector< header > {
     using base = std::vector< header >;
 
 public:
@@ -91,6 +91,8 @@ public:
     void append(const header& head) noexcept (false);
 
     iterator last() const noexcept (true);
+    using base::size;
+    using base::empty;
 
     iterator::difference_type index_of(const iterator&) const noexcept (true);
 
@@ -471,8 +473,8 @@ std::int64_t rp66::readinto(void* dst, std::int64_t len) noexcept (false) {
 
 void rp66::read_header_from_disk() noexcept (false) {
     assert(this->index.empty()                    or
-           this->current     == this->index.end() or
-           this->current + 1 == this->index.end());
+           this->current     == this->index.last() or
+           this->current + 1 == this->index.last());
 
     std::int64_t n;
     unsigned char b[header::size];
@@ -532,7 +534,7 @@ void rp66::read_header_from_disk() noexcept (false) {
 
     std::int64_t base = this->addr.base();
     if ( !this->index.empty() ) {
-        base = this->index.back().base + this->index.back().length;
+        base = this->index.last()->base + this->index.last()->length;
     }
 
     head.base = base;

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -9,6 +9,31 @@
 
 namespace lfp { namespace {
 
+struct header {
+    std::uint16_t  length;
+    unsigned char  format;
+    std::uint8_t   major;
+
+    /*
+     * Visible Records do not contain information about their own initial
+     * offset into the file.  That makes the mapping between offsets of the
+     * underlying bytes and the offset after Visible Envelope is removed a
+     * bit cumbersome. To make this process a bit easier, we augment the
+     * header to include offsets relative to this->zero.
+     *
+     * end_offset is the offset of the last byte contained in the current VR,
+     * relative to this->zero, as if there was no VE.
+     */
+    std::int64_t end_offset = 0;
+
+    /*
+     * Reflects the *actual* number of bytes in the Visible Record Header,
+     * defined here as the VE part of the VR. That is, Visible Record
+     * Length and Format Version.
+     */
+    static constexpr const int size = 4;
+};
+
 class rp66 : public lfp_protocol {
 public:
     rp66(lfp_protocol*);
@@ -27,30 +52,6 @@ public:
     lfp_protocol* peek() const noexcept (false) override;
 
 private:
-    struct header {
-        std::uint16_t  length;
-        unsigned char  format;
-        std::uint8_t   major;
-
-        /*
-         * Visible Records do not contain information about their own initial
-         * offset into the file.  That makes the mapping between offsets of the
-         * underlying bytes and the offset after Visible Envelope is removed a
-         * bit cumbersome. To make this process a bit easier, we augment the
-         * header to include offsets relative to this->zero.
-         *
-         * end_offset is the offset of the last byte contained in the current VR,
-         * relative to this->zero, as if there was no VE.
-         */
-        std::int64_t end_offset = 0;
-
-        /*
-         * Reflects the *actual* number of bytes in the Visible Record Header,
-         * defined here as the VE part of the VR. That is, Visible Record
-         * Length and Format Version.
-         */
-        static constexpr const int size = 4;
-    };
 
     unique_lfp fp;
     std::vector< header > markers;

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -75,7 +75,7 @@ class record_index : private std::vector< header > {
 public:
     using iterator = base::const_iterator;
 
-    void set(const address_map&) noexcept (true);
+    explicit record_index(address_map m);
     /*
      * Check if the logical address offset n is already indexed. If it is, then
      * find() will be defined, and return the correct record.
@@ -206,9 +206,7 @@ std::int64_t address_map::base() const noexcept (true) {
     return this->zero;
 }
 
-void record_index::set(const address_map& m) noexcept (true) {
-    this->addr = m;
-
+record_index::record_index(address_map m) : addr(m) {
     header ghost;
 
     /**
@@ -333,13 +331,19 @@ std::int64_t read_head::tell() const noexcept (true) {
     return (*this)->base + (*this)->length - this->remaining;
 }
 
-rp66::rp66(lfp_protocol* f) : fp(f) {
+std::int64_t baseaddr(lfp_protocol* f) noexcept (true) {
     try {
-        this->addr = address_map(this->fp->tell());
-    } catch (...) {
-        this->addr = address_map();
+        return f->tell();
+    } catch (const lfp::error&) {
+        return 0;
     }
-    this->index.set(this->addr);
+}
+
+rp66::rp66(lfp_protocol* f) :
+    fp(f),
+    addr(baseaddr(f)),
+    index(this->addr)
+{
     this->current = read_head::ghost(this->index.last());
 }
 

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -88,6 +88,8 @@ public:
      */
     iterator find(std::int64_t n) const noexcept (false);
 
+    void append(const header& head) noexcept (false);
+
     iterator last() const noexcept (true);
 
     iterator::difference_type index_of(const iterator&) const noexcept (true);
@@ -130,7 +132,6 @@ private:
 
     std::int64_t readinto(void*, std::int64_t) noexcept (false);
     void read_header_from_disk() noexcept (false);
-    void append(const header&) noexcept (false);
 };
 
 std::int64_t
@@ -171,6 +172,14 @@ record_index::find(std::int64_t n) const noexcept (false) {
             return cur;
 
         cur++;
+    }
+}
+
+void record_index::append(const header& head) noexcept (false) {
+    try {
+        this->push_back(head);
+    } catch (...) {
+        throw runtime_error("rp66: unable to store header");
     }
 }
 
@@ -435,18 +444,9 @@ void rp66::read_header_from_disk() noexcept (false) {
 
     head.base = base;
 
-    this->append(head);
+    this->index.append(head);
     this->current = std::prev(this->index.end());
     this->current.remaining = head.length - header::size;
-}
-
-void rp66::append(const header& head) noexcept (false) try {
-    const auto size = std::int64_t(this->index.size());
-    const auto n = std::max(size - 1, std::int64_t(0));
-    this->index.push_back(head);
-    this->current = this->index.begin() + n;
-} catch (...) {
-    throw runtime_error("rp66: unable to store header");
 }
 
 }

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -393,7 +393,7 @@ int rp66::eof() const noexcept (true) {
 
 std::int64_t rp66::tell() const noexcept (true) {
     const auto pos = this->index.index_of(this->current);
-    return this->addr.logical(this->fp->tell(), pos);
+    return this->addr.logical(this->current.tell(), pos);
 }
 
 void rp66::seek(std::int64_t n) noexcept (false) {

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -155,7 +155,7 @@ void record_index::set(const address_map& m) noexcept (true) {
 
 bool record_index::contains(std::int64_t n) const noexcept (true) {
     const auto last = this->last();
-    return n <= this->addr.logical(last->base + last->length, this->size());
+    return n < this->addr.logical(last->base + last->length, this->size());
 }
 
 record_index::iterator
@@ -167,7 +167,7 @@ record_index::find(std::int64_t n) const noexcept (false) {
         const auto pos = this->index_of(cur);
         const auto off = cur->base + cur->length;
 
-        if (n <= this->addr.logical(off, pos))
+        if (n < this->addr.logical(off, pos))
             return cur;
 
         cur++;
@@ -289,9 +289,15 @@ void rp66::seek(std::int64_t n) noexcept (false) {
         const auto real_offset = this->addr.physical(n, pos);
         const auto end = last->base + last->length;
 
-        if (real_offset <= end) {
+        if (real_offset < end) {
             this->fp->seek(real_offset);
             this->current.remaining = end - real_offset;
+            return;
+        }
+
+        if (real_offset == end) {
+            this->fp->seek(end);
+            this->current.remaining = 0;
             return;
         }
 

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -282,6 +282,7 @@ void rp66::seek(std::int64_t n) noexcept (false) {
      * target is past the already-index'd records, so follow the headers, and
      * index them as we go
      */
+    this->current = cursor(this->index.last());
     while (true) {
         const auto last = this->index.last();
         const auto pos  = this->index.index_of(last);
@@ -290,7 +291,6 @@ void rp66::seek(std::int64_t n) noexcept (false) {
 
         if (real_offset <= end) {
             this->fp->seek(real_offset);
-            this->current = cursor(last);
             this->current.remaining = end - real_offset;
             return;
         }

--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -400,7 +400,7 @@ void rp66::read_header_from_disk() noexcept (false) {
     }
 
     // Check the makefile-provided IS_LITTLE_ENDIAN, or the one set by gcc
-    #if (IS_LITTLE_ENDIAN || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+    #if (defined(IS_LITTLE_ENDIAN) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
         std::reverse(b + 0, b + 2);
     #endif
 


### PR DESCRIPTION
This patch basically takes the internals of tapeimage and adapts them to rp66. The only real difference between tapeimage and rp66 is the headers and how they communicate the relationship between records, making the approach taken in tapeimage applicable to rp66.