### PR TITLE
Add missing header ciso646

### DIFF
--- a/src/rp66.cpp
+++ b/src/rp66.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <ciso646>
 #include <limits>
 #include <vector>
 

--- a/src/tapeimage.cpp
+++ b/src/tapeimage.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <ciso646>
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/test/cfile.cpp
+++ b/test/cfile.cpp
@@ -1,3 +1,5 @@
+#include <ciso646>
+
 #include <catch2/catch.hpp>
 
 #include <lfp/tapeimage.h>

--- a/test/rp66.cpp
+++ b/test/rp66.cpp
@@ -1,3 +1,4 @@
+#include <ciso646>
 #include <vector>
 #include <cstring>
 


### PR DESCRIPTION
ciso646 defines alternative operator representations such as 'and',
'or', and 'not'. Nonconforming compilers, like msvc, requires this
header to be included in order to use these operators. For conforming
compilers, including it has no effect.