### PR TITLE
Fix reading files opened at >2GB tell on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
 
   ubsan:
     docker:
-      - image: ubuntu:rolling
+      - image: ubuntu:latest
     environment:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/src/cfile.cpp
+++ b/src/cfile.cpp
@@ -121,7 +121,7 @@ private:
 
     using unique_file = std::unique_ptr< FILE, del >;
     unique_file fp;
-    long zero = 0;
+    std::int64_t zero = 0;
     std::string ftell_errmsg;
 };
 

--- a/test/cfile.cpp
+++ b/test/cfile.cpp
@@ -425,4 +425,38 @@ TEST_CASE(
         err = lfp_close(cfile);
         CHECK(err == LFP_OK);
     }
+
+    SECTION( "open file after 2GB mark using cfile zero" ) {
+        auto zero = begin + slen - 8;
+        auto* cfile = lfp_cfile_open_at_offset(fp, zero);
+
+        std::int64_t tell;
+        auto err = lfp_tell(cfile, &tell);
+        CHECK(err == LFP_OK);
+        CHECK(tell == 0);
+
+        std::int64_t ptell;
+        err = lfp_ptell(cfile, &ptell);
+        CHECK(err == LFP_OK);
+        CHECK(ptell == zero);
+
+        err = lfp_seek(cfile, 4);
+        CHECK(err == LFP_OK);
+
+        std::int64_t bytes_read = -1;
+        auto out = std::vector< unsigned char >(4, 0xFF);
+        err = lfp_readinto(cfile, out.data(), 4, &bytes_read);
+
+        CHECK(bytes_read == 4);
+        CHECK(err == LFP_OK);
+        CHECK_THAT(out, Equals(expected));
+
+        err = lfp_tell(cfile, &tell);
+        CHECK(err == LFP_OK);
+        CHECK(tell == 8);
+
+        //should delete the file
+        err = lfp_close(cfile);
+        CHECK(err == LFP_OK);
+    }
 }


### PR DESCRIPTION
In 8f119798e82eb9ab4877659aeae00236cb46e402 we fixed a bug that
prevented reading >2GB files on Windows.
In 80e0e6e391bd3d6c25f4fcaf8e23cbbfd0c192e7 we fixed a bug that allowed
us to open new file at any physical tell.

Unfortunately we missed to update the type of one variable, which
resulted in time- and memory consuming crash of any file opened at >2GB
physical tell on Windows.

P.S. Test screenshot before the applied fix
![image](https://user-images.githubusercontent.com/44965282/119518328-b5dfcb80-bd78-11eb-846e-b2f71500a715.png)

