### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
 version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.6
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Current readthedocs built fails, so looks like we need to update the configuration file.
Unfortunately we didn't find a good way to test the readthedocs that is not on master, so we will find out if solution is correct only after merge.