### PR TITLE
Drop permissions in GitHub Actions

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -1,4 +1,5 @@
 name: Architectures
+permissions: {}
 on:
   push:
     branches: [master]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build on Linux
+permissions: {}
 on:
   push:
     branches: [master]

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,4 +1,5 @@
 name: Build on MacOS
+permissions: {}
 on:
   push:
     branches: [master]

--- a/.github/workflows/runtime-analysis.yml
+++ b/.github/workflows/runtime-analysis.yml
@@ -1,4 +1,5 @@
 name: Runtime Analysis
+permissions: {}
 on:
   push:
     branches: [master]

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,5 @@
 name: Static Analysis
+permissions: {}
 on:
   push:
     branches: [master]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,5 @@
 name: Build on Windows
+permissions: {}
 on:
   push:
     branches: [master]


### PR DESCRIPTION
This should resolve the security alerts. 

The tests seem to fail due to some unrelated changes/updates in the toolchain on the runner. I had a brief look and I would like to keep fixes outside the current PR. It might require updating FMT or adding new compiler flags to the windows builds (to enable `/utf-8` as compiler flag).